### PR TITLE
Fixed the issue regarding double tapping a searched item. #15

### DIFF
--- a/app/(tabs)/(read)/downloads/index.tsx
+++ b/app/(tabs)/(read)/downloads/index.tsx
@@ -239,6 +239,7 @@ export default function DownloadsScreen() {
         contentContainerStyle={{ paddingVertical: 16 }}
         showsVerticalScrollIndicator={false}
         className={`flex-1 ${isDark ? 'bg-gray-950' : 'bg-gray-50'}`}
+        keyboardShouldPersistTaps="handled"
       />
     </SafeAreaView>
   );


### PR DESCRIPTION
# Pull Request

## 📋 Description
**Fixes the bug that didn't allow the user to click on a search item (in the downloads page) without closing the keyboard first.**

**What issue does this PR address?**
Fixes #15 

## 🎯 Type of Change
**What type of change is this?**
- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI change (no functional changes)
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔧 Build/CI configuration change

## 📱 Platform Testing
**Which platforms have been tested?**
- [ ] iOS Simulator
- [ ] iOS Device
- [X] Android Emulator
- [ ] Android Device
- [ ] EAS Preview Build

## 🧪 Testing
**How has this been tested?**
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [X] Manual testing completed
- [ ] Tested on multiple devices
- [ ] Tested offline functionality
- [ ] Tested with different languages

**Test Commands:**
```bash
npm start
```

## Test steps
- Open emulator.
- Click on the plus icon button to download a story.
- Type something in the search input (to open the keyboard).
- And it should let you click on any item without having to close the keyboard first.
